### PR TITLE
CUSTESC-71: Implement `extraManifests`

### DIFF
--- a/charts/connector/templates/extra-manifests.yaml
+++ b/charts/connector/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/connector/values.yaml
+++ b/charts/connector/values.yaml
@@ -61,3 +61,12 @@ podAnnotations:
 
 serviceAccount:
   name: ""
+
+# Extra manifests to deploy as an array of objects
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: example-configmap
+  #   data:
+  #     key: value


### PR DESCRIPTION
This seems to be a common practice in the Helm community, as documented here: https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1361

In our case, it can help inject a secret or configmap along with the Helm chart, e.g. for injecting the kubeconfig of a Kubernetes resource as a volume.
