### PR TITLE
Adding sidecar support to connector deployment

### DIFF
--- a/charts/connector/Chart.yaml
+++ b/charts/connector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: connector
-description: The Formal Connector is a protocol-aware proxy that provides visibility and control over the flow of data between your resources and users. 
+description: The Formal Connector is a protocol-aware proxy that provides visibility and control over the flow of data between your resources and users.
 type: application
-version: 0.6.0
+version: 0.7.0

--- a/charts/connector/templates/deployment.yaml
+++ b/charts/connector/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/charts/connector/values.yaml
+++ b/charts/connector/values.yaml
@@ -47,7 +47,7 @@ service:
   # Set the service annotations according to your Kubernetes provider
   # and network topoligy
   annotations: {}
-  
+
   # Optional: restrict source IPs that can access the service
   loadBalancerSourceRanges: []
     # - 10.0.0.0/8
@@ -71,3 +71,6 @@ extraManifests: []
   #     name: example-configmap
   #   data:
   #     key: value
+
+# Additional containers to run in the same pod as the main connector container
+sidecars: []


### PR DESCRIPTION
Add sidecar container support to the connector chart, enabling users to deploy auxiliary containers (e.g., Istio service mesh, Cloud SQL Proxy) alongside the main connector for enhanced connectivity and security requirements.