### PR TITLE
Fix service account annotations not being applied

### DIFF
--- a/charts/connector/templates/serviceaccount.yaml
+++ b/charts/connector/templates/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
     {{- include "connector.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-  {{ . | toYaml | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The template rendered a blank line between the annotations key and its
values:

```yaml
  annotations:

    iam.gke.io/gcp-service-account: example@project.iam.gserviceaccount.com
```

This caused annotations to be ignored, breaking features like GKE
Workload Identity Federation.

Fixed output:

```yaml
  annotations:
    iam.gke.io/gcp-service-account: example@project.iam.gserviceaccount.com
```
