### PR TITLE
Fix name truncation exceeding 63-char DNS limit

### DIFF
--- a/charts/ai-satellite/templates/_helpers.tpl
+++ b/charts/ai-satellite/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "ai-satellite.name" -}}
-{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-") }}
 {{- end }}
 
 {{/*
@@ -12,7 +12,7 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "ai-satellite.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- printf "formal-%s" (.Values.fullnameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (.Values.fullnameOverride | trunc 56 | trimSuffix "-") }}
 {{- else }}
 {{- printf "formal-ai-satellite" }}
 {{- end }}

--- a/charts/connector/templates/_helpers.tpl
+++ b/charts/connector/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "connector.name" -}}
-{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-") }}
 {{- end }}
 
 {{/*
@@ -12,7 +12,7 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "connector.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- printf "formal-%s" (.Values.fullnameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (.Values.fullnameOverride | trunc 56 | trimSuffix "-") }}
 {{- else }}
 {{- printf "formal-connector" }}
 {{- end }}

--- a/charts/data-discovery-satellite/templates/_helpers.tpl
+++ b/charts/data-discovery-satellite/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "data-discovery-satellite.name" -}}
-{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-") }}
 {{- end }}
 
 {{/*
@@ -12,7 +12,7 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "data-discovery-satellite.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- printf "formal-%s" (.Values.fullnameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (.Values.fullnameOverride | trunc 56 | trimSuffix "-") }}
 {{- else }}
 {{- printf "formal-data-discovery-satellite" }}
 {{- end }}

--- a/charts/ecr-cred/templates/_helpers.tpl
+++ b/charts/ecr-cred/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "connector.name" -}}
-{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-") }}
 {{- end }}
 
 {{/*
@@ -12,7 +12,7 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "connector.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- printf "formal-%s" (.Values.fullnameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (.Values.fullnameOverride | trunc 56 | trimSuffix "-") }}
 {{- else }}
 {{- printf "formal-connector" }}
 {{- end }}

--- a/charts/kubernetes-operator/templates/_helpers.tpl
+++ b/charts/kubernetes-operator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "kubernetes-operator.name" -}}
-{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-") }}
 {{- end }}
 
 {{/*
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 */}}
 {{- define "kubernetes-operator.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- printf "formal-%s" (.Values.fullnameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (.Values.fullnameOverride | trunc 56 | trimSuffix "-") }}
 {{- else }}
 {{- printf "formal-kubernetes-operator" }}
 {{- end }}

--- a/charts/policy-data-loader-satellite/templates/_helpers.tpl
+++ b/charts/policy-data-loader-satellite/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "policy-data-loader-satellite.name" -}}
-{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-") }}
 {{- end }}
 
 {{/*
@@ -12,7 +12,7 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "policy-data-loader-satellite.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- printf "formal-%s" (.Values.fullnameOverride | trunc 57 | trimSuffix "-") }}
+{{- printf "formal-%s" (.Values.fullnameOverride | trunc 56 | trimSuffix "-") }}
 {{- else }}
 {{- printf "formal-policy-data-loader-satellite" }}
 {{- end }}


### PR DESCRIPTION
As discussed in #13, if we want to stay within the DNS 63-character limit, the suffix needs to be truncated at 56, not 57 (the `formal-` prefix is 7 characters).

Thanks @DrewGregory!
