### PR TITLE
Support secret-backed env vars in connector and satellite charts

### DIFF
--- a/charts/ai-satellite/Chart.yaml
+++ b/charts/ai-satellite/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ai-satellite
 description: The Formal AI Satellite serves AI features and inference inside your environment.
 type: application
-version: 0.10.0
+version: 0.11.0

--- a/charts/ai-satellite/templates/deployment.yaml
+++ b/charts/ai-satellite/templates/deployment.yaml
@@ -44,9 +44,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "ai-satellite.fullname" . }}
                   key: formal-api-key
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- if and .Values.env (not (kindIs "slice" .Values.env)) }}
+            {{- fail "`.Values.env` must be a list of env entries (e.g. `- name: FOO` with `value:` or `valueFrom:`). The old map form (`env: {FOO: bar}`) is no longer supported; see values.yaml for an example." }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/ai-satellite/values.yaml
+++ b/charts/ai-satellite/values.yaml
@@ -27,10 +27,22 @@ resources:
 
 securityContext: {}
 podSecurityContext: {}
-env: {}
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 tolerations: []
+
+# Extra environment variables for the AI Satellite container.
+# A raw list of Kubernetes env entries, so values can come from a
+# literal or from a Secret/ConfigMap via valueFrom.
+#   env:
+#     - name: KEY_1
+#       value: "literal-value"
+#     - name: KEY_2
+#       valueFrom:
+#         secretKeyRef:
+#           name: my-secret
+#           key: key2
+env: []
 
 # Extra manifests to deploy as an array of objects
 extraManifests: []

--- a/charts/connector/Chart.yaml
+++ b/charts/connector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: connector
 description: The Formal Connector is a protocol-aware proxy that provides visibility and control over the flow of data between your resources and users.
 type: application
-version: 0.12.0
+version: 0.13.0

--- a/charts/connector/templates/deployment.yaml
+++ b/charts/connector/templates/deployment.yaml
@@ -47,9 +47,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "connector.fullname" . }}
                   key: formal-api-key
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- if and .Values.env (not (kindIs "slice" .Values.env)) }}
+            {{- fail "`.Values.env` must be a list of env entries (e.g. `- name: FOO` with `value:` or `valueFrom:`). The old map form (`env: {FOO: bar}`) is no longer supported; see values.yaml for an example." }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/connector/values.yaml
+++ b/charts/connector/values.yaml
@@ -82,6 +82,19 @@ serviceAccount:
   create: true
   name: ""
 
+# Extra environment variables for the Connector container.
+# A raw list of Kubernetes env entries, so values can come from a
+# literal or from a Secret/ConfigMap via valueFrom.
+#   env:
+#     - name: KEY_1
+#       value: "literal-value"
+#     - name: KEY_2
+#       valueFrom:
+#         secretKeyRef:
+#           name: my-secret
+#           key: key2
+env: []
+
 # Extra manifests to deploy as an array of objects
 extraManifests: []
   # - apiVersion: v1

--- a/charts/data-discovery-satellite/Chart.yaml
+++ b/charts/data-discovery-satellite/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: data-discovery-satellite
 description: The Formal Data Discovery Satellite indexes the schemas of datastores within your environment.
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/charts/data-discovery-satellite/templates/deployment.yaml
+++ b/charts/data-discovery-satellite/templates/deployment.yaml
@@ -43,9 +43,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "data-discovery-satellite.fullname" . }}
                   key: formal-api-key
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- if and .Values.env (not (kindIs "slice" .Values.env)) }}
+            {{- fail "`.Values.env` must be a list of env entries (e.g. `- name: FOO` with `value:` or `valueFrom:`). The old map form (`env: {FOO: bar}`) is no longer supported; see values.yaml for an example." }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/data-discovery-satellite/values.yaml
+++ b/charts/data-discovery-satellite/values.yaml
@@ -24,7 +24,6 @@ resources:
 
 securityContext: {}
 podSecurityContext: {}
-env: {}
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 tolerations: []
@@ -34,6 +33,19 @@ tolerations: []
 serviceAccount:
   create: true
   name: ""
+
+# Extra environment variables for the Data Discovery Satellite container.
+# A raw list of Kubernetes env entries, so values can come from a
+# literal or from a Secret/ConfigMap via valueFrom.
+#   env:
+#     - name: KEY_1
+#       value: "literal-value"
+#     - name: KEY_2
+#       valueFrom:
+#         secretKeyRef:
+#           name: my-secret
+#           key: key2
+env: []
 
 # Extra manifests to deploy as an array of objects
 extraManifests: []

--- a/charts/policy-data-loader-satellite/Chart.yaml
+++ b/charts/policy-data-loader-satellite/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: policy-data-loader-satellite
 description: The Formal Policy Data Loader Satellite executes customer-defined code to load arbitrary external data into connector context.
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/charts/policy-data-loader-satellite/templates/deployment.yaml
+++ b/charts/policy-data-loader-satellite/templates/deployment.yaml
@@ -45,9 +45,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "policy-data-loader-satellite.fullname" . }}
                   key: formal-api-key
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- if and .Values.env (not (kindIs "slice" .Values.env)) }}
+            {{- fail "`.Values.env` must be a list of env entries (e.g. `- name: FOO` with `value:` or `valueFrom:`). The old map form (`env: {FOO: bar}`) is no longer supported; see values.yaml for an example." }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/policy-data-loader-satellite/values.yaml
+++ b/charts/policy-data-loader-satellite/values.yaml
@@ -24,7 +24,6 @@ resources:
 
 securityContext: {}
 podSecurityContext: {}
-env: {}
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 tolerations: []
@@ -34,6 +33,19 @@ tolerations: []
 serviceAccount:
   create: true
   name: ""
+
+# Extra environment variables for the Policy Data Loader Satellite container.
+# A raw list of Kubernetes env entries, so values can come from a
+# literal or from a Secret/ConfigMap via valueFrom.
+#   env:
+#     - name: KEY_1
+#       value: "literal-value"
+#     - name: KEY_2
+#       valueFrom:
+#         secretKeyRef:
+#           name: my-secret
+#           key: key2
+env: []
 
 # Extra manifests to deploy as an array of objects
 extraManifests: []


### PR DESCRIPTION
`.Values.env` only renders literal `value:` entries, so custom environment variables cannot be sourced from a Kubernetes Secret. Render `.Values.env` as a raw list so entries can use `valueFrom` (`secretKeyRef`/`configMapKeyRef`) alongside plain `value:`.

⚠️ This changes `env` from a map to a list and thus is a breaking change. The map form should now fail at render time, so existing users would get a loud signal to migrate.
